### PR TITLE
Limit defaults to none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add stacked net load visualization example notebook
 
+### Enhancements
+
+- When using `client.get_dataset()`, the number of rows per request now defaults to maximum allowed by your API key. You can specify a lower limit using the `limit` parameter. We recommend using the default for maximum performance.
+
 ## v0.4.0 - July 31, 2023
 
 ### Enhancements

--- a/gridstatusio/gs_client.py
+++ b/gridstatusio/gs_client.py
@@ -190,7 +190,7 @@ class GridStatusClient:
         filter_column=None,
         filter_value=None,
         filter_operator="=",
-        limit=10000,
+        limit=None,
         max_rows=None,
         tz=None,
         verbose=True,
@@ -212,7 +212,7 @@ class GridStatusClient:
                 Defaults to "=". Possible values are "=",
                 "!=", ">", "<", ">=", "<=", "in".
             limit (int): The maximum number of rows to fetch at time.
-                Defaults to 10000.
+                Defaults maximum allowed by the API.
             max_rows (int): The maximum number of rows to fetch.
                 Defaults to None, which fetches all rows that match the request.
             tz (str): The timezone to convert utc timestamps to. Defaults to UTC.


### PR DESCRIPTION
When using `client.get_dataset()`, the number of rows per request now defaults to maximum allowed by your API key. 

You can specify a lower limit using the `limit` parameter. We recommend using the default for maximum performance.