### PR TITLE
Remove black command from precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,15 +21,6 @@ repos:
     rev: v0.10.1
     hooks:
       - id: validate-pyproject
-  - repo: https://github.com/python/black
-    rev: 22.12.0
-    hooks:
-      - id: black
-        args:
-          - --target-version=py311
-          - --line-length=88
-        additional_dependencies: [".[jupyter]"]
-        types_or: [python, jupyter]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.5.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,10 +57,6 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]
 
-[tool.black]
-line-length = 88
-target-version = ['py311']
-
 [tool.ruff]
 line-length = 88
 lint.ignore = []


### PR DESCRIPTION
Forgot to remove the black related command from the precommit hook in #43 so cleaning that up with this change, now that formatting is covered by ruff.