### PR TITLE
Move dev deps to new section

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1231,4 +1231,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9, <4"
-content-hash = "d071f7d2e00f1159c52c8b44cca55949c680046a18f2fbf3e1dc9639d85cca51"
+content-hash = "69e0351e6d5bf17d1ad3eb1ae642687a93cbe6053357e44afbbf688f6c1b333e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ termcolor = "1.1.0"
 gridstatus = "^0.20.0"
 
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "7.1.2"
 pytest-xdist = "3.0.2"
 pytest-rerunfailures = "10.3"
@@ -42,9 +42,6 @@ pre-commit = "2.21.0"
 plotly = "^5.11.0"
 kaleido = "0.2.1"
 nbformat = "5.1.3"
-
-
-[tool.poetry.group.dev.dependencies]
 ruff = "^0.5.0"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ tqdm = "^4.64.1"
 termcolor = "1.1.0"
 gridstatus = "^0.20.0"
 
-
 [tool.poetry.group.dev.dependencies]
 pytest = "7.1.2"
 pytest-xdist = "3.0.2"


### PR DESCRIPTION
Moves all dev dependencies to `[tool.poetry.group.dev.dependencies]` in `pyproject.toml`.