### PR TITLE
v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.6.3 - Upcoming
+## 0.6.3 - July 15, 2024
 
 - Adds a new `client.get_daily_peak_report()` method for accessing daily peak LMP/load data for a specific ISO and date.
 

--- a/gridstatusio/version.py
+++ b/gridstatusio/version.py
@@ -1,7 +1,7 @@
 import requests
 from termcolor import colored
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 
 
 def get_latest_version():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gridstatusio"
-version = "0.6.2"
+version = "0.6.3"
 readme = "README.md"
 description = "Python Client for GridStatus.io API"
 classifiers = [


### PR DESCRIPTION
## 0.6.3 - July 15, 2024

- Adds a new `client.get_daily_peak_report()` method for accessing daily peak LMP/load data for a specific ISO and date.