### PR TITLE
v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.5 - August 6, 2024
+
+- Remove `gridstatus` and add `tabulate` as dependencies.
+
 ## 0.6.4 - August 2, 2024
 
 - Updates pandas version to allow for pandas 2.0 compatibility

--- a/gridstatusio/version.py
+++ b/gridstatusio/version.py
@@ -1,7 +1,7 @@
 import requests
 from termcolor import colored
 
-__version__ = "0.6.4"
+__version__ = "0.6.5"
 
 
 def get_latest_version():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gridstatusio"
-version = "0.6.4"
+version = "0.6.5"
 readme = "README.md"
 description = "Python Client for GridStatus.io API"
 classifiers = [


### PR DESCRIPTION
## 0.6.5 - August 6, 2024

- Remove `gridstatus` and add `tabulate` as dependencies.