### PR TITLE
Add retries on rate limit hit with exponential backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.0 - TBD
+
+- Adds automatic retries using an exponential backoff when fetching data if an API rate limit is hit. Also adds parameters for configuring `max_retries` on `GridStatusClient` and an optional `sleep_time` parameter on `GridStatusClient.get_dataset`.
+
 ## 0.7.0 - August 28, 2024
 
 - Updates for resampling changes on server. Upsampling is now supported.

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ python -m pip install --upgrade gridstatusio
 * Set your API key as an environment variable: `export GRIDSTATUS_API_KEY=your_api_key`
 * **NOTE**: the Grid Status API has a 1 million rows per month limit on the free plan. This limit is _very_ easy to exceed when querying data, especially real time prices.
   * Make sure to add `limit` to all of your `get_dataset` calls to avoid quickly exceeding the limit.
-* The Grid Status API has rate limits that restrict the number of
-requests that are allowed each second, minute and hour. If rate limits are hit the client will automatically retry the request after a delay. You can configure the maximum number of retries using the `max_retries` parameter when initializing the client. If you find yourself hitting rate limits, you may need to add a delay between your requests.
+* The Grid Status API has rate limits that restrict the number of requests that are allowed each second, minute and hour. If rate limits are hit the client will automatically retry the request after a delay. You can configure the maximum number of retries using the `max_retries` parameter when initializing the client. If you find yourself hitting rate limits, you may need to add a delay between your requests.
 
 Check out this example notebook: [Getting Started](/Examples/Getting%20Started.ipynb)
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ python -m pip install --upgrade gridstatusio
 * Set your API key as an environment variable: `export GRIDSTATUS_API_KEY=your_api_key`
 * **NOTE**: the Grid Status API has a 1 million rows per month limit on the free plan. This limit is _very_ easy to exceed when querying data, especially real time prices.
   * Make sure to add `limit` to all of your `get_dataset` calls to avoid quickly exceeding the limit.
+* The Grid Status API has rate limits that restrict the number of
+requests that are allowed each second, minute and hour. If rate limits are hit the client will automatically retry the request after a delay. You can configure the maximum number of retries using the `max_retries` parameter when initializing the client. If you find yourself hitting rate limits, you may need to add a delay between your requests.
 
 Check out this example notebook: [Getting Started](/Examples/Getting%20Started.ipynb)
 

--- a/gridstatusio/gs_client.py
+++ b/gridstatusio/gs_client.py
@@ -10,8 +10,6 @@ from termcolor import colored
 
 from gridstatusio import __version__, utils
 
-MAX_RETRIES = 3
-
 
 def log(msg, verbose, level="info", end="\n"):
     """Print a message if verbose matches the level"""
@@ -31,6 +29,7 @@ class GridStatusClient:
         api_key=None,
         host="https://api.gridstatus.io/v1",
         request_format="json",
+        max_retries=3,
     ):
         """Create a GridStatus.io API client
 
@@ -43,6 +42,9 @@ class GridStatusClient:
 
             request_format (str): The format to use for requests. Options are "json"
                 or "csv". Defaults to "json".
+
+            max_retries (int): The maximum number of retries to attempt if an API rate
+                limit is hit when requesting data.
         """
 
         if api_key is None:
@@ -60,6 +62,7 @@ class GridStatusClient:
         self.api_key = api_key
         self.host = host
         self.request_format = request_format
+        self.max_retries = max_retries
 
         assert self.request_format in [
             "json",
@@ -94,28 +97,26 @@ class GridStatusClient:
 
         retries = 0
         initial_delay = 1
-        while retries <= MAX_RETRIES:
+        while retries <= self.max_retries:
             response = requests.get(url, params=params, headers=headers)
             if response.status_code == 200:
                 break
-
-            if response.status_code == 429:
-                if retries < MAX_RETRIES:
-                    # Exponential backoff delay  of 1 sec, 2 sec, 4 sec...
-                    delay = initial_delay * 2**retries
-                    retries += 1
-                    log(
-                        (
-                            f"API rate limit hit. Retrying again in {delay} seconds. "
-                            f"Retry {retries} of {MAX_RETRIES}."
-                        ),
-                        verbose=verbose,
-                        level="info",
-                    )
-                    time.sleep(delay)
-                else:
-                    raise Exception("Exceeded maximum number of retries")
-            elif response.status_code != 200:
+            elif (response.status_code == 429) and (retries == self.max_retries):
+                raise Exception("Exceeded maximum number of retries")
+            elif response.status_code == 429:
+                # Exponential backoff delay of 1 sec, 2 sec, 4 sec...
+                delay = initial_delay * 2**retries
+                retries += 1
+                log(
+                    (
+                        f"API rate limit hit. Retrying again in {delay} seconds. "
+                        f"Retry {retries} of {self.max_retries}."
+                    ),
+                    verbose=verbose,
+                    level="info",
+                )
+                time.sleep(delay)
+            else:
                 raise Exception(f"Error {response.status_code}: {response.text}")
 
         if return_raw_response_json:
@@ -233,6 +234,7 @@ class GridStatusClient:
         tz=None,
         verbose=True,
         use_cursor_pagination=True,
+        sleep_time=0,
     ):
         """Get a dataset from GridStatus.io API
 
@@ -295,6 +297,10 @@ class GridStatusClient:
                 the server side to fetch data. Defaults to False. When False, the
                 server will use page-based pagination which is generally slower
                 for large datasets.
+
+            sleep_time (int): The amount of time, in seconds, to wait between requests
+                when requesting multiple pages of data. Can be used to slow request
+                frequency to help avoid hitting API rate limits. Default to 0.
 
         Returns:
             pd.DataFrame: The dataset as a pandas dataframe
@@ -391,6 +397,7 @@ class GridStatusClient:
                 log(f"Total rows: {total_rows:,}/{limit:,} ({pct}% of limit)", verbose)
 
             page += 1
+            time.sleep(sleep_time)
 
         log("", verbose=verbose)  # Add a newline for cleaner output
 

--- a/gridstatusio/gs_client.py
+++ b/gridstatusio/gs_client.py
@@ -44,7 +44,7 @@ class GridStatusClient:
                 or "csv". Defaults to "json".
 
             max_retries (int): The maximum number of retries to attempt if an API rate
-                limit is hit when requesting data.
+                limit is hit when requesting data. Defaults to 3.
         """
 
         if api_key is None:
@@ -300,7 +300,7 @@ class GridStatusClient:
 
             sleep_time (int): The amount of time, in seconds, to wait between requests
                 when requesting multiple pages of data. Can be used to slow request
-                frequency to help avoid hitting API rate limits. Default to 0.
+                frequency to help avoid hitting API rate limits. Defaults to 0.
 
         Returns:
             pd.DataFrame: The dataset as a pandas dataframe

--- a/gridstatusio/tests/test_api.py
+++ b/gridstatusio/tests/test_api.py
@@ -6,7 +6,6 @@ import pandas as pd
 import pytest
 
 import gridstatusio as gs
-from gridstatusio.gs_client import MAX_RETRIES
 from gridstatusio.version import version_is_higher
 
 client = gs.GridStatusClient(
@@ -1041,10 +1040,10 @@ def test_rate_limit_hit_backoff(mock_get_request, capsys):
         )
 
     output_text = capsys.readouterr().out
-    for i in range(0, MAX_RETRIES):
+    for i in range(0, client.max_retries):
         expected_text = (
             f"API rate limit hit. "
             f"Retrying again in {1 * 2 ** i} seconds. "
-            f"Retry {i+1} of {MAX_RETRIES}."
+            f"Retry {i+1} of {client.max_retries}."
         )
         assert expected_text in output_text


### PR DESCRIPTION
Added retry logic in case the client hits an API rate limit. Tested this locally with API limit set to 1 request per second and it seemed to work as expected:

```
>>> data_utc = client.get_dataset(dataset="ercot_spp_day_ahead_hourly", start="2023-04-01", end="2023-04-03", limit=QUERY_LIMIT, page_size=4000)
Fetching Page 1...Done in 0.49 seconds. 
Total rows: 4,000/10,000 (40.0% of limit)
Fetching Page 2...API rate limit hit. Retrying again in 1 seconds. Retry 1 of 3.
Done in 1.66 seconds. Total time: 2.15s. Avg per page: 1.07s
Total rows: 8,000/10,000 (80.0% of limit)
Fetching Page 3...API rate limit hit. Retrying again in 1 seconds. Retry 1 of 3.
Done in 1.64 seconds. Total time: 3.79s. Avg per page: 1.26s
Total rows: 10,000/10,000 (100.0% of limit)

Total number of rows: 10000
```

Also confirmed an exception gets raised if all retries fail:
```
>>> data_utc = client.get_dataset(dataset="ercot_spp_day_ahead_hourly", start="2023-04-01", end="2023-04-03", limit=QUERY_LIMIT, page_size=4000)
Fetching Page 1...Done in 1.71 seconds. 
Total rows: 4,000/10,000 (40.0% of limit)
Fetching Page 2...API rate limit hit. Retrying again in 1 seconds. Retry 1 of 3.
Done in 1.69 seconds. Total time: 3.4s. Avg per page: 1.7s
Total rows: 8,000/10,000 (80.0% of limit)
Fetching Page 3...API rate limit hit. Retrying again in 1 seconds. Retry 1 of 3.
API rate limit hit. Retrying again in 2 seconds. Retry 2 of 3.
API rate limit hit. Retrying again in 4 seconds. Retry 3 of 3.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/nate/dev/gridstatusio/gridstatusio/gs_client.py", line 363, in get_dataset
    df, meta, dataset_metadata = self.get(url, params=params, verbose=verbose)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nate/dev/gridstatusio/gridstatusio/gs_client.py", line 117, in get
    raise Exception("Exceeded maximum number of retries")
Exception: Exceeded maximum number of retries
```