### PR TITLE
Reduce Parallelization During Testing to Stay within Rate Limits

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-      # max-parallel: 1
+      max-parallel: 1
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-      max-parallel: 1
+      # max-parallel: 1
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,6 +6,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
+      max-parallel: 1
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ clean:
 	find . -name '*~' -delete
 	find . -name '.coverage.*' -delete
 
-PYTEST_CMD := poetry run pytest -s -vv gridstatusio/ -n auto
+PYTEST_CMD := poetry run pytest -s -vv gridstatusio/ -n 2
 NOT_SLOW := -m "not slow"
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,17 @@ clean:
 	find . -name '*~' -delete
 	find . -name '.coverage.*' -delete
 
-PYTEST_CMD := poetry run pytest -s -vv gridstatusio/ -n 2
+PYTEST_CMD := poetry run pytest -s -vv gridstatusio/
 NOT_SLOW := -m "not slow"
 
 .PHONY: test
 test:
 	$(PYTEST_CMD) $(NOT_SLOW) --reruns 5 --reruns-delay 3
+
+# Running tests in parallel will generally result in rate limiting from the API
+.PHONY: test-parallel
+test-parallel:
+	$(PYTEST_CMD) $(NOT_SLOW) -n auto
 
 .PHONY: test-slow
 test-slow:

--- a/gridstatusio/gs_client.py
+++ b/gridstatusio/gs_client.py
@@ -102,7 +102,7 @@ class GridStatusClient:
             if response.status_code == 200:
                 break
             elif (response.status_code == 429) and (retries == self.max_retries):
-                raise Exception("Exceeded maximum number of retries")
+                raise Exception("Rate limited. Exceeded maximum number of retries")
             elif response.status_code == 429:
                 # Exponential backoff delay of 1 sec, 2 sec, 4 sec...
                 delay = initial_delay * 2**retries

--- a/gridstatusio/tests/test_api.py
+++ b/gridstatusio/tests/test_api.py
@@ -1032,7 +1032,10 @@ def test_invalid_resampling_frequency():
 @patch("requests.get")
 def test_rate_limit_hit_backoff(mock_get_request, capsys):
     mock_get_request.return_value.status_code = 429
-    with pytest.raises(Exception, match="Exceeded maximum number of retries"):
+    with pytest.raises(
+        Exception,
+        match="Rate Limited. Exceeded maximum number of retries",
+    ):
         client.get_dataset(
             "pjm_load",
             start="2024-01-01",

--- a/gridstatusio/tests/test_api.py
+++ b/gridstatusio/tests/test_api.py
@@ -1034,7 +1034,7 @@ def test_rate_limit_hit_backoff(mock_get_request, capsys):
     mock_get_request.return_value.status_code = 429
     with pytest.raises(
         Exception,
-        match="Rate Limited. Exceeded maximum number of retries",
+        match="Rate limited. Exceeded maximum number of retries",
     ):
         client.get_dataset(
             "pjm_load",


### PR DESCRIPTION
- Remove parallelization when running tests to stay under the server rate limits
