### PR TITLE
Release 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.11.0 - May 30, 2025
 
+- Add support for filtering data by publish time
 - Add support for specifying `timezone=market` when querying datasets to return local timestamps in the ISO timezone
 
 ## 0.10.1 - May 9, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-# 0.10.1 - May 9, 2025
+## 0.11.0 - May 30, 2025
+
+- Add support for specifying `timezone=market` when querying datasets to return local timestamps in the ISO timezone
+
+## 0.10.1 - May 9, 2025
 
 - Switch to `uv` for package management
 

--- a/gridstatusio/version.py
+++ b/gridstatusio/version.py
@@ -1,7 +1,7 @@
 import requests
 from termcolor import colored
 
-__version__ = "0.10.1"
+__version__ = "0.11.0"
 
 
 def get_latest_version():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gridstatusio"
-version = "0.10.1"
+version = "0.11.0"
 description = "Python Client for GridStatus.io API"
 authors = [{ name = "Max Kanter", email = "kmax12@gmail.com" }]
 requires-python = ">=3.9, <4"


### PR DESCRIPTION
- Add support for filtering data by publish time
- Add support for specifying `timezone=market` when querying datasets to return local timestamps in the ISO timezone