### PR TITLE
feat: better logging and version checking controls

### DIFF
--- a/gridstatusio/gs_client.py
+++ b/gridstatusio/gs_client.py
@@ -1,4 +1,5 @@
 import io
+import logging
 import time
 import warnings
 from datetime import datetime
@@ -386,6 +387,9 @@ class GridStatusClient:
         Returns:
             pd.DataFrame: The dataset as a pandas dataframe
         """
+        if not verbose:
+            logger.setLevel(logging.ERROR)
+
         if tz:
             warnings.warn(
                 "The 'tz' parameter is deprecated. Please use 'timezone' instead.",
@@ -543,6 +547,10 @@ class GridStatusClient:
                         df = df.rename(
                             columns={col_name: col_name.replace("_utc", "") + "_local"},
                         )
+
+        # Restore logger level if it was changed
+        if not verbose:
+            logger.setLevel(logging.INFO)
 
         return df
 

--- a/gridstatusio/tests/test_api.py
+++ b/gridstatusio/tests/test_api.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 import gridstatusio as gs
+from gridstatusio.utils import silence_deprecation_warnings
 
 client = gs.GridStatusClient(
     api_key=os.getenv("GRIDSTATUS_API_KEY_TEST"),
@@ -275,7 +276,7 @@ def test_filter_operator_in():
     _check_dataframe(df)
 
 
-def test_get_dataset_verbose(caplog):
+def test_get_dataset_verbose_false(caplog):
     # Set log level to capture all logs
     caplog.set_level("INFO")
 
@@ -291,6 +292,8 @@ def test_get_dataset_verbose(caplog):
     # Clear the log records
     caplog.clear()
 
+
+def test_get_dataset_verbose_true(caplog):
     # Test verbose=True - should log params and timing
     client.get_dataset(
         dataset="isone_fuel_mix",
@@ -349,19 +352,20 @@ def test_handles_all_nan_columns():
     time_columns = ["interval_start_utc", "interval_end_utc"]
     time_columns_local = ["interval_start_local", "interval_end_local"]
 
-    # with time zone
-    df = client.get_dataset(
-        "nyiso_standardized_5_min",
-        start=start,
-        end=end,
-        tz="America/New_York",
-        columns=time_columns + [btm_col],
-    )
+    # with tz
+    with silence_deprecation_warnings():
+        df = client.get_dataset(
+            "nyiso_standardized_5_min",
+            start=start,
+            end=end,
+            tz="America/New_York",
+            columns=time_columns + [btm_col],
+        )
 
-    assert set(time_columns_local + [btm_col]) == set(df.columns)
-    assert pd.api.types.is_datetime64_any_dtype(df[time_columns_local[0]])
-    assert pd.api.types.is_datetime64_any_dtype(df[time_columns_local[1]])
-    assert df[btm_col].dtype == "object"
+        assert set(time_columns_local + [btm_col]) == set(df.columns)
+        assert pd.api.types.is_datetime64_any_dtype(df[time_columns_local[0]])
+        assert pd.api.types.is_datetime64_any_dtype(df[time_columns_local[1]])
+        assert df[btm_col].dtype == "object"
 
     # without timezone
     df = client.get_dataset(
@@ -383,18 +387,19 @@ def test_handles_no_results():
     time_columns_local = ["interval_start_local", "interval_end_local"]
 
     # no data, with time zone
-    df = client.get_dataset(
-        "nyiso_btm_solar",
-        start="2020-01-01",
-        end="2020-01-02",
-        tz="America/New_York",
-        columns=time_columns + [btm_col],
-    )
+    with silence_deprecation_warnings():
+        df = client.get_dataset(
+            "nyiso_btm_solar",
+            start="2020-01-01",
+            end="2020-01-02",
+            tz="America/New_York",
+            columns=time_columns + [btm_col],
+        )
 
-    assert set(time_columns_local + [btm_col]) == set(df.columns)
-    assert pd.api.types.is_datetime64_any_dtype(df[time_columns_local[0]])
-    assert pd.api.types.is_datetime64_any_dtype(df[time_columns_local[1]])
-    assert df[btm_col].dtype == "object"
+        assert set(time_columns_local + [btm_col]) == set(df.columns)
+        assert pd.api.types.is_datetime64_any_dtype(df[time_columns_local[0]])
+        assert pd.api.types.is_datetime64_any_dtype(df[time_columns_local[1]])
+        assert df[btm_col].dtype == "object"
 
     # no data, without timezone
     df = client.get_dataset(
@@ -410,13 +415,14 @@ def test_handles_no_results():
     assert df[btm_col].dtype == "object"
 
     # this date range crosses from no data to data, with timezone
-    df = client.get_dataset(
-        "nyiso_btm_solar",
-        start="2020-11-16",
-        end="2020-11-18",
-        tz="America/New_York",
-        columns=time_columns + [btm_col],
-    )
+    with silence_deprecation_warnings():
+        df = client.get_dataset(
+            "nyiso_btm_solar",
+            start="2020-11-16",
+            end="2020-11-18",
+            tz="America/New_York",
+            columns=time_columns + [btm_col],
+        )
 
     assert set(time_columns_local + [btm_col]) == set(df.columns)
     assert pd.api.types.is_datetime64_any_dtype(df[time_columns_local[0]])
@@ -531,16 +537,17 @@ def test_resample_frequency():
     )
 
     # test tz
-    df = client.get_dataset(
-        dataset="ercot_real_time_as_monitor",
-        start="2023-08-01",
-        end="2023-08-02",
-        columns=["time_utc", "prc"],
-        # dont need to specify plural
-        resample="1 hour",
-        tz="America/Chicago",
-        verbose=True,
-    )
+    with silence_deprecation_warnings():
+        df = client.get_dataset(
+            dataset="ercot_real_time_as_monitor",
+            start="2023-08-01",
+            end="2023-08-02",
+            columns=["time_utc", "prc"],
+            # dont need to specify plural
+            resample="1 hour",
+            tz="America/Chicago",
+            verbose=True,
+        )
 
     _check_dataframe(
         df,

--- a/gridstatusio/tests/test_timezone_behavior.py
+++ b/gridstatusio/tests/test_timezone_behavior.py
@@ -4,6 +4,7 @@ from typing import cast
 import pytest
 
 import gridstatusio as gs
+from gridstatusio.utils import silence_deprecation_warnings
 
 client = gs.GridStatusClient(
     api_key=os.getenv("GRIDSTATUS_API_KEY_TEST"),
@@ -43,13 +44,14 @@ class TestTimezoneBehavior:
     ]
 
     def test_tz_only(self):
-        df = client.get_dataset(
-            self.dataset,
-            start=self.start,
-            end=self.end,
-            tz=self.tz,
-            columns=self.columns,
-        )
+        with silence_deprecation_warnings():
+            df = client.get_dataset(
+                self.dataset,
+                start=self.start,
+                end=self.end,
+                tz=self.tz,
+                columns=self.columns,
+            )
         assert df.columns.tolist() == self.expected_columns_with_tz
 
         assert str(df["interval_start_local"].min()) == "2024-11-30 16:00:00-08:00"
@@ -71,15 +73,16 @@ class TestTimezoneBehavior:
         assert str(df["interval_end_utc"].max()) == "2024-12-01 01:00:00+00:00"
 
     def test_tz_and_timezone(self):
-        with pytest.raises(ValueError):
-            client.get_dataset(
-                self.dataset,
-                start=self.start,
-                end=self.end,
-                tz=self.tz,
-                timezone=self.timezone,
-                columns=self.columns,
-            )
+        with silence_deprecation_warnings():
+            with pytest.raises(ValueError):
+                client.get_dataset(
+                    self.dataset,
+                    start=self.start,
+                    end=self.end,
+                    tz=self.tz,
+                    timezone=self.timezone,
+                    columns=self.columns,
+                )
 
     def test_no_tz_and_no_timezone(self):
         df = client.get_dataset(
@@ -95,16 +98,17 @@ class TestTimezoneBehavior:
         assert str(df["interval_end_utc"].max()) == "2024-12-01 01:00:00+00:00"
 
     def test_tz_on_dst_start(self):
-        self.start = "2024-03-10T08:00:00Z"
-        self.end = "2024-03-10T12:00:00Z"
+        with silence_deprecation_warnings():
+            self.start = "2024-03-10T08:00:00Z"
+            self.end = "2024-03-10T12:00:00Z"
 
-        df = client.get_dataset(
-            self.dataset,
-            start=self.start,
-            end=self.end,
-            tz=self.tz,
-            columns=self.columns,
-        )
+            df = client.get_dataset(
+                self.dataset,
+                start=self.start,
+                end=self.end,
+                tz=self.tz,
+                columns=self.columns,
+            )
 
         assert df.columns.tolist() == self.expected_columns_with_tz
 
@@ -131,16 +135,17 @@ class TestTimezoneBehavior:
         assert str(df["interval_end_local"].max()) == "2024-03-10 05:00:00-07:00"
 
     def test_tz_on_dst_end(self):
-        self.start = "2024-11-03T08:00:00Z"
-        self.end = "2024-11-03T12:00:00Z"
+        with silence_deprecation_warnings():
+            self.start = "2024-11-03T08:00:00Z"
+            self.end = "2024-11-03T12:00:00Z"
 
-        df = client.get_dataset(
-            self.dataset,
-            start=self.start,
-            end=self.end,
-            tz=self.tz,
-            columns=self.columns,
-        )
+            df = client.get_dataset(
+                self.dataset,
+                start=self.start,
+                end=self.end,
+                tz=self.tz,
+                columns=self.columns,
+            )
 
         assert df.columns.tolist() == self.expected_columns_with_tz
 
@@ -167,16 +172,17 @@ class TestTimezoneBehavior:
         assert str(df["interval_end_local"].max()) == "2024-11-03 04:00:00-08:00"
 
     def test_tz_with_naive_start_and_end(self):
-        self.start = "2024-12-01 00:00:00"
-        self.end = "2024-12-01 01:00:00"
+        with silence_deprecation_warnings():
+            self.start = "2024-12-01 00:00:00"
+            self.end = "2024-12-01 01:00:00"
 
-        df = client.get_dataset(
-            self.dataset,
-            start=self.start,
-            end=self.end,
-            tz=self.tz,
-            columns=self.columns,
-        )
+            df = client.get_dataset(
+                self.dataset,
+                start=self.start,
+                end=self.end,
+                tz=self.tz,
+                columns=self.columns,
+            )
 
         assert df.columns.tolist() == self.expected_columns_with_tz
 

--- a/gridstatusio/tests/test_version.py
+++ b/gridstatusio/tests/test_version.py
@@ -1,6 +1,9 @@
+import os
+from unittest.mock import MagicMock, patch
+
 import pytest
 
-from gridstatusio.version import version_is_higher
+from gridstatusio.version import check_for_update, version_is_higher
 
 
 @pytest.mark.parametrize(
@@ -16,3 +19,42 @@ from gridstatusio.version import version_is_higher
 )
 def test_version_is_higher(latest, current, expected):
     assert version_is_higher(latest, current) == expected
+
+
+def test_version_check_disabled():
+    """Test that version check is skipped when environment variable is set"""
+    # Set the environment variable
+    os.environ["GSIO_SKIP_VERSION_CHECK"] = "1"
+
+    # Mock the requests.get to ensure it's not called
+    with patch("requests.get") as mock_get:
+        check_for_update()
+
+        # Verify that requests.get was never called
+        mock_get.assert_not_called()
+
+
+def test_version_check_enabled():
+    """Test that version check runs when environment variable is not set"""
+    # Remove the environment variable if it exists
+    os.environ.pop("GSIO_SKIP_VERSION_CHECK", None)
+
+    # Mock the requests.get to return a fake response
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"info": {"version": "0.14.0"}}
+
+    with patch("requests.get", return_value=mock_response) as mock_get:
+        check_for_update()
+
+        # Verify that requests.get was called
+        mock_get.assert_called_once_with("https://pypi.org/pypi/gridstatusio/json")
+
+
+@pytest.mark.parametrize("env_value", ["1", "true", "yes", "on", "anything"])
+def test_version_check_with_different_values(env_value):
+    """Test that any value for the environment variable disables the check"""
+    os.environ["GSIO_SKIP_VERSION_CHECK"] = env_value
+
+    with patch("requests.get") as mock_get:
+        check_for_update()
+        mock_get.assert_not_called()

--- a/gridstatusio/tests/test_version.py
+++ b/gridstatusio/tests/test_version.py
@@ -23,30 +23,23 @@ def test_version_is_higher(latest, current, expected):
 
 def test_version_check_disabled():
     """Test that version check is skipped when environment variable is set"""
-    # Set the environment variable
     os.environ["GSIO_SKIP_VERSION_CHECK"] = "1"
-
-    # Mock the requests.get to ensure it's not called
     with patch("requests.get") as mock_get:
         check_for_update()
 
-        # Verify that requests.get was never called
         mock_get.assert_not_called()
 
 
 def test_version_check_enabled():
     """Test that version check runs when environment variable is not set"""
-    # Remove the environment variable if it exists
     os.environ.pop("GSIO_SKIP_VERSION_CHECK", None)
 
-    # Mock the requests.get to return a fake response
     mock_response = MagicMock()
     mock_response.json.return_value = {"info": {"version": "0.14.0"}}
 
     with patch("requests.get", return_value=mock_response) as mock_get:
         check_for_update()
 
-        # Verify that requests.get was called
         mock_get.assert_called_once_with("https://pypi.org/pypi/gridstatusio/json")
 
 

--- a/gridstatusio/utils.py
+++ b/gridstatusio/utils.py
@@ -1,4 +1,6 @@
 import logging
+import warnings
+from contextlib import contextmanager
 
 import pandas as pd
 
@@ -44,3 +46,11 @@ def handle_date(
             date = date.tz_convert(tz)
 
     return date
+
+
+@contextmanager
+def silence_deprecation_warnings():
+    """Context manager to temporarily silence deprecation warnings."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        yield

--- a/gridstatusio/version.py
+++ b/gridstatusio/version.py
@@ -1,3 +1,5 @@
+import os
+
 import requests
 from termcolor import colored
 
@@ -25,6 +27,10 @@ def version_is_higher(latest: str, current: str) -> bool:
 
 
 def check_for_update() -> None:
+    # NB: Option to skip version check if environment variable is set
+    if os.getenv("GSIO_SKIP_VERSION_CHECK"):
+        return
+
     latest = get_latest_version()
     if version_is_higher(latest, __version__):
         print(


### PR DESCRIPTION
## User quality of life options

Including:
1. `version.py:check_for_update()` can be disabled simply by setting the `GSIO_SKIP_VERSION_CHECK` environment variable. Helps turn off this check for systems that don't have access to PyPI and thus would error on this check. Default behavior is maintained

2. `client.get_dataset()` now handles all logging through the `verbose` kwarg, setting the logging level to report `ERROR`s only when `verbose=False`. Handles https://github.com/gridstatus/gridstatusio/issues/88

#### Example w/ `verbose=True`:
```
df = client.get_dataset("caiso_fuel_mix", start="2025-01-01", end="2025-01-02", verbose=True)
print(df)
```
<img width="1314" height="362" alt="CleanShot 2025-07-28 at 15 27 21" src="https://github.com/user-attachments/assets/521441c2-e821-4665-9501-261f8e40531c" />


#### Example w/ `verbose=False`:
```
df = client.get_dataset("caiso_fuel_mix", start="2025-01-01", end="2025-01-02", verbose=False)
print(df)
```
<img width="1285" height="242" alt="CleanShot 2025-07-28 at 15 28 42" src="https://github.com/user-attachments/assets/e4eda129-d26b-4647-9702-35b8a08d8e9c" />


### Other Stuff:
- Silence the `tz` kwarg deprecation error in tests (most of the time the test is checking whether the `tz` kwarg still works. But we know this is deprecated and don't need to be told a dozen times when running the tests). 