### PR TITLE
Fix SCED Test

### DIFF
--- a/gridstatusio/tests/test_api.py
+++ b/gridstatusio/tests/test_api.py
@@ -46,7 +46,7 @@ def test_uses_columns():
     _check_dataframe(df, columns=columns, length=limit)
 
     # no columns specified
-    ncols = 29
+    ncols = 30
     df = client.get_dataset(dataset=dataset, verbose=True, limit=limit)
     assert df.shape == (limit, ncols), "Expected all columns"
 


### PR DESCRIPTION
- Fixes a test that had the incorrect number of columns after the addition of `sced2_offer_curve` to `ercot_sced_gen_resource_60_day`
  - https://www.gridstatus.io/datasets/ercot_sced_gen_resource_60_day#columns
