### PR TITLE
fix(client,version): add timeout to all requests.get calls

### DIFF
--- a/gridstatusio/gs_client.py
+++ b/gridstatusio/gs_client.py
@@ -58,6 +58,7 @@ class GridStatusClient:
         max_retries: int = 5,
         base_delay: float = 2.0,
         exponential_base: float = 2.0,
+        timeout: float | None = 30.0,
     ):
         """Create a GridStatus.io API client
 
@@ -84,6 +85,10 @@ class GridStatusClient:
 
             exponential_base (float): Base for exponential backoff calculation.
                 Defaults to 2.0.
+
+            timeout (float | None): Seconds to wait for a server response before
+                raising a Timeout exception. Applies to both connect and read.
+                Defaults to 30.0. Set to None to wait indefinitely.
         """
 
         if api_key is None:
@@ -102,6 +107,7 @@ class GridStatusClient:
         self.max_retries = max_retries
         self.base_delay = base_delay
         self.exponential_base = exponential_base
+        self.timeout = timeout
 
         assert self.request_format in [
             "json",
@@ -391,7 +397,12 @@ class GridStatusClient:
 
         while retries <= self.max_retries:
             try:
-                response = requests.get(url, params=params, headers=headers)
+                response = requests.get(
+                    url,
+                    params=params,
+                    headers=headers,
+                    timeout=self.timeout,
+                )
 
                 if response.status_code == 200:
                     break

--- a/gridstatusio/tests/test_version.py
+++ b/gridstatusio/tests/test_version.py
@@ -40,4 +40,7 @@ def test_version_check_enabled():
     with patch("requests.get", return_value=mock_response) as mock_get:
         check_for_update()
 
-        mock_get.assert_called_once_with("https://pypi.org/pypi/gridstatusio/json")
+        mock_get.assert_called_once_with(
+            "https://pypi.org/pypi/gridstatusio/json",
+            timeout=3,
+        )

--- a/gridstatusio/version.py
+++ b/gridstatusio/version.py
@@ -9,7 +9,10 @@ __version__ = "0.15.1"
 def get_latest_version() -> str:
     """Get the latest version of gridstatusio from PyPI"""
 
-    response = requests.get("https://pypi.org/pypi/gridstatusio/json")  # noqa: E501
+    response = requests.get(
+        "https://pypi.org/pypi/gridstatusio/json",
+        timeout=3,
+    )
     latest_version = response.json()["info"]["version"]
     return latest_version
 
@@ -31,7 +34,10 @@ def check_for_update() -> None:
     if os.getenv("GSIO_SKIP_VERSION_CHECK") == "true":
         return
 
-    latest = get_latest_version()
+    try:
+        latest = get_latest_version()
+    except Exception:
+        return
     if version_is_higher(latest, __version__):
         print(
             # make bold


### PR DESCRIPTION
## Summary

This PR fixes two `requests.get()` calls that had no timeout set, found via static analysis with [Bandit](https://bandit.readthedocs.io) (rule B113: `request_without_timeout`, CWE-400).

## Issues

**1. API requests can hang indefinitely (`gs_client.py`)**

`_get_with_retry()` calls `requests.get()` with no timeout. If a TCP connection is established but the server stalls, the call blocks forever, there is no OS-level default. `requests.exceptions.Timeout` is already listed in `RETRIABLE_EXCEPTIONS`, but it is only raised when a timeout is actually set, so the existing retry logic never fires in this scenario. A caller's process can hang permanently with no recovery path.

**2. Import-time PyPI version check can also hang (`version.py`)**

`check_for_update()` is called on `import gridstatusio`. The underlying `requests.get("https://pypi.org/pypi/gridstatusio/json")` had no timeout, so a slow or unreachable PyPI could make the library unimportable until the OS TCP timeout fires (potentially several minutes). `GSIO_SKIP_VERSION_CHECK` exists as an escape hatch, but a user hitting this cold won't know to use it.

## Changes

- `GridStatusClient` gains a `timeout` parameter (default `30.0` seconds) passed directly to `requests.get()`. The default can be overridden at construction time; set a lower value for latency-sensitive pipelines or `None` to restore the previous unbounded behavior.
- The PyPI version check uses a hardcoded `timeout=3`. Network errors are now swallowed silently since the check is informational only.

## Validation

- `bandit -r gridstatusio/ -ll` reports **no issues** after these changes (previously two medium-severity findings).
- No behavior change for successful requests; the `timeout` default of 30s is well above normal API response times.