### PR TITLE
Add batteries column to ISONE fuel mix resample test

### DIFF
--- a/gridstatusio/tests/test_api.py
+++ b/gridstatusio/tests/test_api.py
@@ -678,6 +678,7 @@ def test_resample_frequency(client, return_format):
             "solar",
             "wind",
             "wood",
+            "batteries",
         ],
     )
 


### PR DESCRIPTION
## What changed
`test_resample_frequency` pinned the exact column set returned for the `isone_fuel_mix` dataset. The live dataset now includes a `batteries` fuel type, which broke the assertion across all three return-format parametrizations (pandas/polars/python). Added `batteries` to the expected columns, appended last to match the API's column order.

This is upstream data drift, not a client code change.

## How to validate
```
uv run pytest "gridstatusio/tests/test_api.py::test_resample_frequency" --reruns 5 --reruns-delay 3
```
All three parametrizations pass. Full non-slow suite: 161 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)