### PR TITLE
Update free plan row limit to 500k/month in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ data = client.get_dataset('ercot_fuel_mix', limit=100, start='2025-01-01', end='
 
 * To see all available datasets, use `client.list_datasets()` or check out the complete Grid Status catalog at https://www.gridstatus.io/datasets
 
-* **NOTE**: the Grid Status API has a 1 million rows per month limit on the free plan. This limit is _very_ easy to exceed when querying data, especially real time prices.
+* **NOTE**: the Grid Status API has a 500,000 rows per month limit on the free plan. This limit is _very_ easy to exceed when querying data, especially real time prices.
   * Make sure to add `limit` to all of your `get_dataset` calls to avoid quickly exceeding the limit.
 
 


### PR DESCRIPTION
## Summary
The README stated the GridStatus API free plan has a **1 million rows/month** limit, but the current [pricing page](https://www.gridstatus.io/pricing) lists **500,000 rows/month** for the Free plan. This PR treats the pricing page as authoritative and corrects the README.

## Changes
- `README.md`: free plan limit `1 million rows per month` → `500,000 rows per month`

🤖 Generated with [Claude Code](https://claude.com/claude-code)