### PR TITLE
[ENG-4180] Prepare 0.16.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-## 0.16.0 - June 21, 2026
+## 0.16.0 - July 7, 2026
 
 ### New Features
 
 - Add optional return formats to `GridStatusClient`: choose between Pandas DataFrames (default), Polars DataFrames, or Python lists of dicts via the `return_format` parameter, set once on the client or per API call. `polars` is an optional dependency, and `return_format="python"` works without importing pandas thanks to lazy loading.
 - Add support for Python 3.14.
+- Add `get_dataset_metadata()` method to `GridStatusClient` for retrieving metadata for a single dataset (description, available time range, columns, and more). Returns a `DatasetMetadata` typed dict regardless of the client's `return_format` or `request_format`, with timestamp fields parsed into timezone-aware `datetime` objects.
+- `list_datasets(return_list=True)` now returns typed `DatasetMetadata` entries with timestamp fields (keys ending in `_utc`) parsed into timezone-aware `datetime` objects instead of ISO 8601 strings. The `DatasetMetadata` and `DatasetColumn` types are importable from the package root.
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.16.0 - June 21, 2026
+
+### New Features
+
+- Add optional return formats to `GridStatusClient`: choose between Pandas DataFrames (default), Polars DataFrames, or Python lists of dicts via the `return_format` parameter, set once on the client or per API call. `polars` is an optional dependency, and `return_format="python"` works without importing pandas thanks to lazy loading.
+- Add support for Python 3.14.
+
+### Dependencies
+
+- Add `brotli` (`brotlicffi` on PyPy) to negotiate Brotli response compression, decoding payloads roughly 40% smaller than gzip transparently with no changes to the request path.
+
+### Documentation
+
+- Update the free plan row limit to 500k/month in the README.
+
 ## 0.15.1 - December 3, 2025
 
 ### Bug Fixes

--- a/gridstatusio/version.py
+++ b/gridstatusio/version.py
@@ -3,7 +3,7 @@ import os
 import requests
 from termcolor import colored
 
-__version__ = "0.15.1"
+__version__ = "0.16.0"
 
 
 def get_latest_version() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gridstatusio"
-version = "0.15.1"
+version = "0.16.0"
 description = "Python Client for GridStatus.io API"
 authors = [{ name = "Max Kanter", email = "kmax12@gmail.com" }]
 requires-python = ">=3.10, <4"

--- a/uv.lock
+++ b/uv.lock
@@ -567,7 +567,7 @@ wheels = [
 
 [[package]]
 name = "gridstatusio"
-version = "0.15.1"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "brotli", marker = "platform_python_implementation == 'CPython'" },


### PR DESCRIPTION
## What changed

Bump version `0.15.1` → `0.16.0` and add the changelog entry for this release.

- `pyproject.toml`, `gridstatusio/version.py`, `uv.lock`: version bump.
- `CHANGELOG.md`: new `0.16.0` section covering the changes merged since `0.15.1`:
  - New: optional return formats (`return_format` — pandas/polars/python) (#102)
  - New: Python 3.14 support (#100)
  - New: `get_dataset_metadata()` helper and typed `DatasetMetadata` returns, with `_utc` timestamps parsed to timezone-aware datetimes in `get_dataset_metadata()` and `list_datasets()` (#117)
  - Dependency: brotli response compression (#107)
  - Docs: free plan row limit updated to 500k/month in the README (#109)

A minor bump (not a patch) because this release includes new features.

## How to validate

```
uv sync
uv run pytest gridstatusio/tests
```

- Version is consistent across `pyproject.toml`, `gridstatusio/version.py`, and `uv.lock` (all `0.16.0`), so the release workflow's tag-vs-version guard will pass for a `v0.16.0` tag.
- `uv sync` resolves cleanly against the regenerated lockfile.

After merge, publishing the PyPI release is a separate step: create a GitHub Release with tag `v0.16.0` targeting `main`, which triggers `.github/workflows/release.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)